### PR TITLE
transport in ios_ modules depracted in ansible 2.4

### DIFF
--- a/network-lab/group_vars/all.yml
+++ b/network-lab/group_vars/all.yml
@@ -3,4 +3,4 @@ ioscli:
   username: "{{ansible_user}}"
   password: "{{ansible_password}}"
   host: "{{inventory_hostname}}"
-  transport: cli
+  port: 22


### PR DESCRIPTION
dict object "transport:"  in provider deprecated in ansible 2.4, now using "port:"
